### PR TITLE
add member-fn predeccessor() and successor()

### DIFF
--- a/include/std/net/ip/address_v4.hpp
+++ b/include/std/net/ip/address_v4.hpp
@@ -133,6 +133,12 @@ public:
   /// Determine whether the address is a multicast address.
   STDNET_DECL bool is_multicast() const;
 
+  /// Determine the successor address.
+  STDNET_DECL address_v4 successor() const;
+
+  /// Determine the predeccessor address.
+  STDNET_DECL address_v4 predeccessor() const;
+
   /// Compare two addresses for equality.
   friend bool operator==(const address_v4& a1, const address_v4& a2)
   {

--- a/include/std/net/ip/address_v6.hpp
+++ b/include/std/net/ip/address_v6.hpp
@@ -151,6 +151,12 @@ public:
   /// Determine whether the address is a site-local multicast address.
   STDNET_DECL bool is_multicast_site_local() const;
 
+  /// Determine the successor address.
+  STDNET_DECL address_v6 successor() const;
+
+  /// Determine the predeccessor address.
+  STDNET_DECL address_v6 predeccessor() const;
+
   /// Compare two addresses for equality.
   STDNET_DECL friend bool operator==(
       const address_v6& a1, const address_v6& a2);

--- a/include/std/net/ip/impl/address_v4.ipp
+++ b/include/std/net/ip/impl/address_v4.ipp
@@ -150,6 +150,22 @@ bool address_v4::is_multicast() const
   return (to_ulong() & 0xF0000000) == 0xE0000000;
 }
 
+address_v4 address_v4::successor() const
+{
+  if ( 0xFFFFFFFF == to_ulong() )
+    return address_v4();
+  else
+    return address_v4( to_ulong() + 1);
+}
+
+address_v4 address_v4::predeccessor() const
+{
+  if ( 0 == to_ulong() )
+    return address_v4();
+  else
+    return address_v4( to_ulong() - 1);
+}
+
 address_v4 address_v4::broadcast(const address_v4& addr, const address_v4& mask)
 {
   return address_v4(addr.to_ulong() | (mask.to_ulong() ^ 0xFFFFFFFF));

--- a/include/std/net/ip/impl/address_v6.ipp
+++ b/include/std/net/ip/impl/address_v6.ipp
@@ -243,6 +243,62 @@ bool address_v6::is_multicast_site_local() const
   return ((addr_.s6_addr[0] == 0xff) && ((addr_.s6_addr[1] & 0x0f) == 0x05));
 }
 
+address_v6 address_v6::successor() const
+{
+  using namespace std; // For memcpy.
+  std::net::detail::in6_addr_type addr;
+  memcpy(&addr, &addr_, sizeof( addr_));
+  bool valid = false;
+  for ( int i = 15; 0 <= i; --i)
+  {
+        if ( 0xff == addr.s6_addr[i])
+           addr.s6_addr[i] = 0;
+        else
+        {
+            ++addr.s6_addr[i];
+            valid = true;
+            break;
+        } 
+  }
+  if ( valid)
+  {
+      bytes_type bytes;
+      memcpy(bytes.data(), addr.s6_addr, 16);
+      // FIXME: take care about the scope
+      return address_v6( bytes, scope_id_);
+  }
+  else
+      return address_v6();
+}
+
+address_v6 address_v6::predeccessor() const
+{
+  using namespace std; // For memcpy.
+  std::net::detail::in6_addr_type addr;
+  memcpy(&addr, &addr_, sizeof( addr_));
+  bool valid = false;
+  for ( int i = 15; 0 <= i; --i)
+  {
+        if ( 0 == addr.s6_addr[i])
+           addr.s6_addr[i] = 0xff;
+        else
+        {
+            --addr.s6_addr[i];
+            valid = true;
+            break;
+        } 
+  }
+  if ( valid)
+  {
+      bytes_type bytes;
+      memcpy(bytes.data(), addr.s6_addr, 16);
+      // FIXME: take care about the scope
+      return address_v6( bytes, scope_id_);
+  }
+  else
+      return address_v6();
+}
+
 bool operator==(const address_v6& a1, const address_v6& a2)
 {
   using namespace std; // For memcmp.

--- a/tests/ip/address_v4.cpp
+++ b/tests/ip/address_v4.cpp
@@ -246,6 +246,14 @@ void test()
   STDNET_CHECK(address_v4::netmask(address_v4(0xEFFFFFFF)) == other_net);
   STDNET_CHECK(address_v4::netmask(address_v4(0xF0000000)) == other_net);
   STDNET_CHECK(address_v4::netmask(address_v4(0xFFFFFFFF)) == other_net);
+
+  STDNET_CHECK(address_v4::from_string("172.1.1.2") == address_v4::from_string("172.1.1.1").successor() );
+  STDNET_CHECK(address_v4::from_string("224.0.0.0") == address_v4::from_string("223.255.255.255").successor() );
+  STDNET_CHECK(address_v4() == address_v4::from_string("255.255.255.255").successor() );
+
+  STDNET_CHECK(address_v4::from_string("172.1.1.1") == address_v4::from_string("172.1.1.2").predeccessor() );
+  STDNET_CHECK(address_v4::from_string("223.255.255.255") == address_v4::from_string("224.0.0.0").predeccessor() );
+  STDNET_CHECK(address_v4() == address_v4::any().predeccessor() );
 }
 
 } // namespace ip_address_v4_runtime

--- a/tests/ip/address_v6.cpp
+++ b/tests/ip/address_v6.cpp
@@ -351,6 +351,11 @@ void test()
   STDNET_CHECK(mcast_site_local_address.is_multicast_site_local());
 
   STDNET_CHECK(address_v6::loopback().is_loopback());
+
+  STDNET_CHECK(address_v6::from_string("2001::1") == address_v6::from_string("2001::").successor() );
+  STDNET_CHECK(address_v6::from_string("2001::1:0") == address_v6::from_string("2001::ffff").successor() );
+  STDNET_CHECK(address_v6::from_string("2001::") == address_v6::from_string("2001::1").predeccessor() );
+  STDNET_CHECK(address_v6::from_string("2001::ffff") == address_v6::from_string("2001::1:0").predeccessor() );
 }
 
 } // namespace ip_address_v6_runtime


### PR DESCRIPTION
calculate the predeccessor/successor for IPv4/IPv6 address
